### PR TITLE
pytest-subprocess 1.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d7693b96f588f39b84c7b2b5c04287459246dfae6be1dd4098937a728ad4fbe3
+  url: https://github.com/aklajnert/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+  sha256: 80172ac95439cd4a237c5ee7f343227a7fd21fb61284bfa0de4b7802502d88dc
 
 build:
   number: 0
@@ -29,8 +29,19 @@ test:
     - pytest_subprocess
   requires:
     - pip
+    - docutils >=0.12
+    - pygments >=2.0
+    - pytest-rerunfailures
+    - pytest-asyncio >=0.15.1
+    - pytest-timeout
+    - anyio
+  source_files:
+    - tests
+    - README.rst
+    - docs/index.rst
   commands:
     - pip check
+    - pytest -v tests
 
 about:
   home: https://pypi.org/project/pytest-subprocess/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,36 +6,45 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pytest-subprocess-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: d7693b96f588f39b84c7b2b5c04287459246dfae6be1dd4098937a728ad4fbe3
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
   number: 0
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
+    - wheel    
   run:
-    - python >=3.6
+    - python
     - pytest >=4.0.0
 
 test:
   imports:
     - pytest_subprocess
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://pypi.org/project/pytest-subprocess/
-  summary: A plugin to fake subprocess for pytest
-  dev_url: https://github.com/aklajnert/pytest-subprocess
   license: MIT
+  license_family: MIT
   license_file: LICENSE
+  summary: A plugin to fake subprocess for pytest
+  description: |
+    The plugin adds the fake_process fixture (and fp as an alias). It can be used it to register 
+    subprocess results so you won't need to rely on the real processes. The plugin hooks on the 
+    subprocess.Popen(), which is the base for other subprocess functions. That makes the subprocess.run(), 
+    subprocess.call(), subprocess.check_call() and subprocess.check_output() methods also functional.
+  dev_url: https://github.com/aklajnert/pytest-subprocess
+  doc_url: https://github.com/aklajnert/pytest-subprocess#usage
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<37]
+  skip: true  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -55,7 +55,7 @@ about:
     subprocess.Popen(), which is the base for other subprocess functions. That makes the subprocess.run(), 
     subprocess.call(), subprocess.check_call() and subprocess.check_output() methods also functional.
   dev_url: https://github.com/aklajnert/pytest-subprocess
-  doc_url: https://github.com/aklajnert/pytest-subprocess#usage
+  doc_url: https://pytest-subprocess.readthedocs.io/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
[PKG-3299] pytest-subprocess 1.5.0

- upstream: https://github.com/aklajnert/pytest-subprocess/tree/1.5.0
- dependency files:
    - https://github.com/aklajnert/pytest-subprocess/blob/1.5.0/setup.py
- conda-forge: https://github.com/conda-forge/pytest-subprocess-feedstock
- pypi: https://pypi.org/project/pytest-subprocess
    
**Destination channel:** `defaults`

**Changes**
- new package, fix recipe, linter, version `1.5.0`, remove `no-arch`
- add upstream tests

**Dependency for**
- AnacondaRecipes/scikit-build-core-feedstock#1

[PKG-3299]: https://anaconda.atlassian.net/browse/PKG-3299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ